### PR TITLE
Rebuild for both OpenSSL 1 and 3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  jcmorin-ana-org: qt
+
+upload_without_merge: true

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  jcmorin-ana-org: qt
-
-upload_without_merge: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
     - patches/0010-cumulative-ossl3.patch
 
 build:
-  number: 0
+  number: 1
   # no groff on s390x ...
   skip: True  # [linux and s390x]
   missing_dso_whitelist:          # [osx]
@@ -57,15 +57,13 @@ requirements:
     - krb5 1.20.1
     - openssl {{ openssl }}
     - libdb ==6.2.*  # [win]
-    - libntlm 1.5    # [unix]
     - sqlite 3       # [win]
     - ldap3 2.9.1    # [win]
   run:
     - krb5
-    - openssl 3.*
-    - libntlm  # [unix]
+    - openssl  # exact pin handled through openssl run_exports
     - libdb    # [win]
-    
+
 test:
   commands:
     - echo "DONE"


### PR DESCRIPTION
Rebuild for both OpenSSL 1 and 3. This is required for mysql, which is needed by [qt-main](https://github.com/AnacondaRecipes/qt-main-feedstock/pull/5).