### PR TITLE
Rebuild with krb5 1.21.3

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,0 @@
-c_compiler:  # [win]
-  - vs2019   # [win]
-cxx_compiler:  # [win]
-  - vs2019     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,9 +25,7 @@ source:
     - patches/0010-cumulative-ossl3.patch
 
 build:
-  number: 1
-  # no groff on s390x ...
-  skip: True  # [linux and s390x]
+  number: 2
   missing_dso_whitelist:          # [osx]
     - /usr/lib/libresolv.9.dylib  # [osx]
     - /usr/lib/libpam.2.dylib     # [osx]
@@ -39,6 +37,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - libtool      # [unix]
@@ -48,21 +47,17 @@ requirements:
     - make         # [unix]
     - groff        # [unix]
     - patch        # [not win]
-    - m2-patch    # [win]
+    - m2-patch     # [win]
     - git          # [unix]
     - m2-bash      # [win]
     - m2-patch     # [win]
     - m2-gcc-libs  # [win]
   host:
-    - krb5 1.20.1
+    - krb5 {{ krb5 }}
     - openssl {{ openssl }}
-    - libdb ==6.2.*  # [win]
-    - sqlite 3       # [win]
-    - ldap3 2.9.1    # [win]
-  run:
-    - krb5
-    - openssl  # exact pin handled through openssl run_exports
-    - libdb    # [win]
+    - libdb ==6.2.*        # [win]
+    - sqlite {{ sqlite }}  # [win]
+    - ldap3 2.9.1          # [win]
 
 test:
   commands:


### PR DESCRIPTION
cyrus-sasl v2.1.28 b2

**Destination channel:** defaults

### Links

- [PKG-8634](https://anaconda.atlassian.net/browse/PKG-8634)
- [Upstream repository](https://github.com/cyrusimap/cyrus-sasl/tree/cyrus-sasl-2.1.28)
- Relevant dependency PRs:
  - AnacondaRecipes/krb5-feedstock#11

### Explanation of changes:

- Use aggregate CBC pin for krb5


[PKG-8634]: https://anaconda.atlassian.net/browse/PKG-8634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ