### PR TITLE
PKG-13865 Remove ntlm usage

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -35,7 +35,6 @@ pushd plugins
   if not exist gssapiv2_init.c bash -lc "./makeinit.sh gssapiv2_init.c"
   if not exist kerberos4_init.c bash -lc "./makeinit.sh kerberos4_init.c"
   if not exist login_init.c bash -lc "./makeinit.sh login_init.c"
-  if not exist ntlm_init.c bash -lc "./makeinit.sh ntlm_init.c"
   if not exist otp_init.c bash -lc "./makeinit.sh otp_init.c"
   if not exist passdss_init.c bash -lc "./makeinit.sh passdss_init.c"
   if not exist plain_init.c bash -lc "./makeinit.sh plain_init.c"
@@ -47,17 +46,11 @@ popd
 :skip_makeinit
 :: We could modify makeinit.sh to include ../common/plugin_common.h
 xcopy /I /F /Y common\plugin_common.h plugins
-:: .. but then we also hit
-:: ntlm.c
-:: ntlm.c(100): fatal error C1083: Cannot open include file: 'crypto-compat.h': No such file or directory
-:: .. so something more fundamental is not working
-xcopy /I /F /Y common\crypto-compat.h plugins
 
 nmake /f NTMakefile ^
         VERBOSE=1 ^
         DB_LIB=libdb62.lib ^
         STATIC=no ^
-        NTLM=1 ^
         GSSAPI=MIT ^
         SQL=SQLITE3 ^
         SRP=1 ^

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "cyrus-sasl" %}
 {% set version = "2.1.28" %}
 
+
 package:
   name: {{ name }}
   version: {{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "cyrus-sasl" %}
 {% set version = "2.1.28" %}
 
-
 package:
   name: {{ name }}
   version: {{ version }}
@@ -25,7 +24,7 @@ source:
     - patches/0011-Add-time-header.patch # [linux]
 
 build:
-  number: 4
+  number: 5
   missing_dso_whitelist:          # [osx]
     - /usr/lib/libresolv.9.dylib  # [osx]
     - /usr/lib/libpam.2.dylib     # [osx]

--- a/recipe/patches/0008-Commit-the-plugin_init.c-files.patch
+++ b/recipe/patches/0008-Commit-the-plugin_init.c-files.patch
@@ -12,14 +12,13 @@ Subject: [PATCH 8/8] Commit the plugin_init.c files
  plugins/gssapiv2_init.c  | 43 ++++++++++++++++++++++++++++++++++++++++
  plugins/kerberos4_init.c | 43 ++++++++++++++++++++++++++++++++++++++++
  plugins/login_init.c     | 43 ++++++++++++++++++++++++++++++++++++++++
- plugins/ntlm_init.c      | 43 ++++++++++++++++++++++++++++++++++++++++
  plugins/otp_init.c       | 43 ++++++++++++++++++++++++++++++++++++++++
  plugins/passdss_init.c   | 43 ++++++++++++++++++++++++++++++++++++++++
  plugins/plain_init.c     | 43 ++++++++++++++++++++++++++++++++++++++++
  plugins/sasldb_init.c    | 38 +++++++++++++++++++++++++++++++++++
  plugins/scram_init.c     | 43 ++++++++++++++++++++++++++++++++++++++++
  plugins/srp_init.c       | 43 ++++++++++++++++++++++++++++++++++++++++
- 15 files changed, 598 insertions(+), 1 deletion(-)
+ 14 files changed, 555 insertions(+), 1 deletion(-)
  create mode 100644 plugins/anonymous_init.c
  create mode 100644 plugins/crammd5_init.c
  create mode 100644 plugins/digestmd5_init.c
@@ -27,7 +26,6 @@ Subject: [PATCH 8/8] Commit the plugin_init.c files
  create mode 100644 plugins/gssapiv2_init.c
  create mode 100644 plugins/kerberos4_init.c
  create mode 100644 plugins/login_init.c
- create mode 100644 plugins/ntlm_init.c
  create mode 100644 plugins/otp_init.c
  create mode 100644 plugins/passdss_init.c
  create mode 100644 plugins/plain_init.c
@@ -387,55 +385,6 @@ index 0000000..cad7575
 +
 +SASL_CLIENT_PLUG_INIT( login )
 +SASL_SERVER_PLUG_INIT( login )
-+
-diff --git a/plugins/ntlm_init.c b/plugins/ntlm_init.c
-new file mode 100644
-index 0000000..a336fda
---- /dev/null
-+++ b/plugins/ntlm_init.c
-@@ -0,0 +1,43 @@
-+
-+#include <config.h>
-+
-+#include <string.h>
-+#include <stdlib.h>
-+#include <stdio.h>
-+#ifndef macintosh
-+#include <sys/stat.h>
-+#endif
-+#include <fcntl.h>
-+#include <assert.h>
-+
-+#include <sasl.h>
-+#include <saslplug.h>
-+#include <saslutil.h>
-+
-+#include "plugin_common.h"
-+
-+#ifdef macintosh
-+#include <sasl_ntlm_plugin_decl.h>
-+#endif
-+
-+#ifdef WIN32
-+BOOL APIENTRY DllMain( HANDLE hModule, 
-+                       DWORD  ul_reason_for_call, 
-+                       LPVOID lpReserved
-+					 )
-+{
-+    switch (ul_reason_for_call)
-+	{
-+		case DLL_PROCESS_ATTACH:
-+		case DLL_THREAD_ATTACH:
-+		case DLL_THREAD_DETACH:
-+		case DLL_PROCESS_DETACH:
-+			break;
-+    }
-+    return TRUE;
-+}
-+#endif
-+
-+SASL_CLIENT_PLUG_INIT( ntlm )
-+SASL_SERVER_PLUG_INIT( ntlm )
 +
 diff --git a/plugins/otp_init.c b/plugins/otp_init.c
 new file mode 100644


### PR DESCRIPTION
## Remove NTLM support from cyrus-sasl

### Links
- [PKG-13865](https://anaconda.atlassian.net/browse/PKG-13865) — remove libntlm usage
- [upstream issue #708](https://github.com/cyrusimap/cyrus-sasl/issues/708) — Remove NTLM support
- [cyrus-sasl dev](https://github.com/cyrusimap/cyrus-sasl)

### Changes
- `bld.bat`: removed `ntlm_init.c` generation via `makeinit.sh`
- `bld.bat`: removed `NTLM=1` flag from nmake invocation
- `bld.bat`: removed `xcopy crypto-compat.h` workaround that existed solely for the broken NTLM build
- `patches/0008-Commit-the-plugin_init.c-files.patch`: removed `ntlm_init.c` hunk

### Notes
- NTLM was already disabled on Linux/macOS — `build.sh` never passed `--with-ntlm` to `./configure`; this is a Windows-only cleanup
- NTLM support is scheduled for removal in upstream cyrus-sasl 2.2.0 — [issue #708](https://github.com/cyrusimap/cyrus-sasl/issues/708) (closed, milestone 2.2.0)
- Microsoft is actively deprecating NTLM in favor of Kerberos
- `crypto-compat.h` is still copied correctly for the SRP plugin via the NTMakefile rule added in `0004-openssl-1.1.1-support-on-windows.patch` — the removed `xcopy` was redundant

[PKG-13865]: https://anaconda.atlassian.net/browse/PKG-13865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ